### PR TITLE
fix: index highest-level theorems too

### DIFF
--- a/database/informalize.py
+++ b/database/informalize.py
@@ -50,7 +50,7 @@ def generate_informal(conn: Connection, batch_size: int = 50, limit_level: int |
     tasks = []
 
     with conn.cursor() as cursor, conn.cursor() as insert_cursor:
-        for l in range(limit_level):
+        for l in range(limit_level + 1):
             query = """
                 SELECT s.name, d.signature, d.value, d.docstring, d.kind, m.docstring, d.module_name, d.index
                 FROM


### PR DESCRIPTION
### This PR

Makes it so that highest-level theorems get informalised (and, therefore, indexed) too.

So, given this in the database after jixia:

<img width="300px" src="https://github.com/user-attachments/assets/a62bb0b1-38f8-4449-ab33-21a17f20a9a4"/>

#### BEFORE

`make index; python3 search.py "hi"`

```
0:
Distance: 0.22232073019793364
theorem even_plus_even  (a b : Nat) : is_even a → is_even b → is_even (a + b)
Elaborated type: ∀ (a b : Nat), is_even a → is_even b → is_even (a + b)
Sum of Even Numbers is Even: For any natural numbers \( a \) and \( b \), if \( a \) is even and \( b \) is even, then the sum \( a + b \) is also even.

1:
Distance: 0.2267613290256949
theorem odd_plus_odd  (a b : Nat) : is_odd a → is_odd b → is_even (a + b)
Elaborated type: ∀ (a b : Nat), is_odd a → is_odd b → is_even (a + b)
Sum of Two Odd Natural Numbers is Even: For any natural numbers \( a \) and \( b \), if \( a \) is odd and \( b \) is odd, then the sum \( a + b \) is even.

2:
Distance: 0.24312543724174962
definition is_odd  (n : Nat)
Elaborated type: Nat → Prop
Odd natural number: A natural number \( n \) is odd if its remainder when divided by 2 is equal to 1, i.e., \( n \equiv 1 \mod 2 \).

3:
Distance: 0.2469675709638257
definition is_even  (n : Nat)
Elaborated type: Nat → Prop
Even natural number: A natural number \( n \) is even if its remainder when divided by 2 is 0, i.e., \( n \equiv 0 \mod 2 \).

---
```

#### AFTER

`make index; python3 search.py "hi"`

```
0:
Distance: 0.22243655692973663
theorem even_plus_even  (a b : Nat) : is_even a → is_even b → is_even (a + b)
Elaborated type: ∀ (a b : Nat), is_even a → is_even b → is_even (a + b)
Sum of Even Numbers is Even: For any natural numbers \( a \) and \( b \), if \( a \) is even and \( b \) is even, then the sum \( a + b \) is also even.

1:
Distance: 0.22866035659129857
theorem odd_plus_odd  (a b : Nat) : is_odd a → is_odd b → is_even (a + b)
Elaborated type: ∀ (a b : Nat), is_odd a → is_odd b → is_even (a + b)
Sum of Two Odd Natural Numbers is Even: For any natural numbers \( a \) and \( b \), if \( a \) and \( b \) are odd, then their sum \( a + b \) is even.

2:
Distance: 0.2321960072288144
theorem sum_four_nums  (a b c d : Nat) : is_even a → is_even b → is_odd c → is_odd d → is_even (a + b + c + d)
Elaborated type: ∀ (a b c d : Nat), is_even a → is_even b → is_odd c → is_odd d → is_even (a + b + c + d)
Sum of Two Even and Two Odd Natural Numbers is Even: For any natural numbers \( a, b, c, d \), if \( a \) and \( b \) are even and \( c \) and \( d \) are odd, then the sum \( a + b + c + d \) is even.

3:
Distance: 0.24315180129369174
definition is_odd  (n : Nat)
Elaborated type: Nat → Prop
Odd natural number: A natural number \( n \) is odd if its remainder when divided by 2 is equal to 1, i.e., \( n \equiv 1 \mod 2 \).

4:
Distance: 0.24611052780747766
definition is_even  (n : Nat)
Elaborated type: Nat → Prop
Even natural number: A natural number \( n \) is even if it satisfies \( n \equiv 0 \mod 2 \), i.e., \( n \) is divisible by 2.

---
```