### PR TITLE
refactor: make all env vars required

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,5 +39,4 @@ EMBEDDING_DEVICE = "cpu"
 # LOG_FILEMODE = ...
 
 # Log level.
-# [Default is "WARNING"]
-# LOG_LEVEL = ...
+LOG_LEVEL = "WARNING"

--- a/.env.example
+++ b/.env.example
@@ -31,8 +31,8 @@ CHROMA_PATH     = "chroma"
 EMBEDDING_DEVICE = "cpu"
 
 # Name of the log file.
-# [Default is logging to console]
-# LOG_FILENAME = ...
+# "" results in logging to console.
+LOG_FILENAME = ""
 
 # Log file mode.
 # "w" for overwriting and "a" for appending.

--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,7 @@ OPENAI_MODEL    = "deepseek-chat"
 CHROMA_PATH     = "chroma"
 
 # Torch device to compute the embedding (https://pytorch.org/docs/stable/tensor_attributes.html#torch.device)
-# [Default is "cpu"]
-# EMBEDDING_DEVICE = ...
+EMBEDDING_DEVICE = "cpu"
 
 # Name of the log file.
 # [Default is logging to console]

--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,12 @@
-############ API KEYS YOU MUST SET YOURSELF ############
+############ ENV VARIABLES YOU MUST SET YOURSELF ############
 
 # Path to the jixia executable.
 # For example, suppose jixia repo was cloned to `/home/tony/Desktop/jixia`. Then `JIXIA_PATH` should be set to `/home/tony/Desktop/jixia/.lake/build/bin/jixia`.
-JIXIA_PATH        = "/home/tony/Desktop/jixia/.lake/build/bin/jixia"
+JIXIA_PATH = "/home/tony/Desktop/jixia/.lake/build/bin/jixia"
 
 # System root of your Lean 4 installation
 # This can be found by running `lake env` and copying the `LEAN_SYSROOT` line.
-LEAN_SYSROOT      = "/home/tony/.elan/toolchains/leanprover--lean4---v4.18.0"
+LEAN_SYSROOT = "/home/tony/.elan/toolchains/leanprover--lean4---v4.18.0"
 
 # Connection string used to connect to the PostgreSQL database. 
 # Use the postgres database name you created.
@@ -14,18 +14,18 @@ CONNECTION_STRING = "dbname=your_db_name"
 
 # OpenAI-compatible API key.
 # Use your deepseek key.
-OPENAI_API_KEY    = "sk-fakefakefakefakefakefakefake"
+OPENAI_API_KEY = "sk-fakefakefakefakefakefakefake"
 
-#################### DEFAULT VALUES ####################
+################### DEFAULT ENV VARIABLES ###################
 
 # OpenAI-compatible API endpoint
 OPENAI_BASE_URL = "https://api.deepseek.com"
 
 # Model to use
-OPENAI_MODEL    = "deepseek-chat"
+OPENAI_MODEL = "deepseek-chat"
 
 # Path to the folder where to store ChromaDB files.
-CHROMA_PATH     = "chroma"
+CHROMA_PATH = "chroma"
 
 # Torch device to compute the embedding (https://pytorch.org/docs/stable/tensor_attributes.html#torch.device)
 EMBEDDING_DEVICE = "cpu"

--- a/.env.example
+++ b/.env.example
@@ -34,9 +34,9 @@ EMBEDDING_DEVICE = "cpu"
 # [Default is logging to console]
 # LOG_FILENAME = ...
 
-# Log file mode.  "w" for overwriting and "a" for appending.
-# [Default is "w"]
-# LOG_FILEMODE = ...
+# Log file mode.
+# "w" for overwriting and "a" for appending.
+LOG_FILEMODE = "w"
 
 # Log level.
 LOG_LEVEL = "WARNING"

--- a/database/__main__.py
+++ b/database/__main__.py
@@ -8,7 +8,7 @@ from . import main
 
 dotenv.load_dotenv()
 logging.basicConfig(
-    filename=os.environ.get("LOG_FILENAME"),
+    filename=os.environ["LOG_FILENAME"] or None,
     filemode=os.environ["LOG_FILEMODE"],
     level=os.environ["LOG_LEVEL"],
 )

--- a/database/__main__.py
+++ b/database/__main__.py
@@ -9,7 +9,7 @@ from . import main
 dotenv.load_dotenv()
 logging.basicConfig(
     filename=os.environ.get("LOG_FILENAME"),
-    filemode=os.environ.get("LOG_FILEMODE", "w"),
+    filemode=os.environ["LOG_FILEMODE"],
     level=os.environ["LOG_LEVEL"],
 )
 jixia.run.executable = os.environ["JIXIA_PATH"]

--- a/database/__main__.py
+++ b/database/__main__.py
@@ -10,7 +10,7 @@ dotenv.load_dotenv()
 logging.basicConfig(
     filename=os.environ.get("LOG_FILENAME"),
     filemode=os.environ.get("LOG_FILEMODE", "w"),
-    level=os.environ.get("LOG_LEVEL", "WARNING").upper(),
+    level=os.environ["LOG_LEVEL"],
 )
 jixia.run.executable = os.environ["JIXIA_PATH"]
 

--- a/database/vector_db.py
+++ b/database/vector_db.py
@@ -1,7 +1,6 @@
 import os
 
 import chromadb
-import torch.cuda
 from jixia.structs import pp_name
 from psycopg import Connection
 
@@ -12,11 +11,7 @@ def create_vector_db(conn: Connection, path: str, batch_size: int):
     with open("prompt/embedding_instruction.txt") as fp:
         instruction = fp.read()
     MistralEmbedding.setup_env()
-    try:
-        device = os.environ["EMBEDDING_DEVICE"]
-    except KeyError:
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-    embedding = MistralEmbedding(device, instruction)
+    embedding = MistralEmbedding(os.environ["EMBEDDING_DEVICE"], instruction)
 
     client = chromadb.PersistentClient(path)
     collection = client.create_collection(

--- a/retrieve/retrieve.py
+++ b/retrieve/retrieve.py
@@ -34,7 +34,7 @@ class Retriever:
         self.collection = self.client.get_collection(name="leansearch", embedding_function=None)
         with open("prompt/retrieve_instruction.txt") as fp:
             instruction = fp.read()
-        self.embedding = MistralEmbedding(os.environ.get("EMBEDDING_DEVICE", "cpu"), instruction)
+        self.embedding = MistralEmbedding(os.environ["EMBEDDING_DEVICE"], instruction)
 
     def batch_search(self, query: list[str], num_results: int) -> list[list[QueryResult]]:
         query_embedding = self.embedding.embed(query)


### PR DESCRIPTION
Makes all env vars required as discussed here https://github.com/frenzymath/LeanSearch/pull/2#issuecomment-2814589614.

All of the env vars from `.env.example` would have to be explicitly set in production too now.