### PR TITLE
refactor: remove reference to exemplary statements from the prompt

### DIFF
--- a/database/translate.py
+++ b/database/translate.py
@@ -71,6 +71,8 @@ class TranslationEnvironment:
                     messages=[
                         {"role": "user", "content": prompt},
                     ],
+                    # ___Why don't we use `response_format={ 'type': 'json_object' }`?
+                    #    DeepSeek support for json is rather limited at the moment, in our case it will be raising parse errors on LaTeX escape characters.
                     stream=False,
                 )
             except JSONDecodeError:  # DeepSeek API is not available right now

--- a/prompt/definition.md.j2
+++ b/prompt/definition.md.j2
@@ -3,7 +3,7 @@
 
 Suppose you are an expert mathematician and an expert in Lean and Mathlib.
 
-1. Your task is to first translate the formal definition provided below into an informal statement that is more accessible to mathematicians written in Latex. There are six parts of information attached to the definition.
+1. Your task is to first translate the formal definition provided below into an informal statement that is more accessible to mathematicians written in Latex. There are five parts of information attached to the definition.
 
    * Head statements, including important statements, theorems, definitions of the mathmatical field the theorem in.
    * The kind of the statement. It could be a definition, a structure, a class, an inductive, a classInductive or an opaque.

--- a/prompt/definition.md.j2
+++ b/prompt/definition.md.j2
@@ -10,7 +10,6 @@ Suppose you are an expert mathematician and an expert in Lean and Mathlib.
    * Docstrings. In most cases, the docstrings contains the informal explanation of the formal statement, written by human. In this case, you should make good use of the doctrings and include all mathematical information in the docstrings in your translation of statement. Sometimes the docstring also contains implimentation notes, which should not appear in your translation.
    * Neighbor statements that are next to the given statement.
    * Dependent definitions or statements used in the definition.
-   * Similar translation exemplary statements. They are written by human and attached information of the exemplary statements and of high quality. You should learn their way of using the information and follow their style of informalization.
 
    Utilize these information to better understand the formal definition. Make sure you follow the principles of informal statement when you translate the formal definition into informal statement.
 

--- a/prompt/instance.md.j2
+++ b/prompt/instance.md.j2
@@ -3,7 +3,7 @@
 
 Suppose you are an expert mathematician and an expert in Lean and Mathlib.
 
-1. Your task is to first translate the formal instance provided below into an informal statement that is more accessible to mathematicians written in Latex. There are five parts of information attached to the instance.
+1. Your task is to first translate the formal instance provided below into an informal statement that is more accessible to mathematicians written in Latex. There are four parts of information attached to the instance.
 
    * Head statements, including important statements, theorems, definitions of the mathmatical field the theorem in.
    * Docstrings. In most cases, the docstrings contains the informal explanation of the formal statement, written by human. In this case, you should make good use of the doctrings and include all mathematical information in the docstrings in your translation of statement. Sometimes the docstring also contains implimentation notes, which should not appear in your translation.

--- a/prompt/instance.md.j2
+++ b/prompt/instance.md.j2
@@ -9,7 +9,6 @@ Suppose you are an expert mathematician and an expert in Lean and Mathlib.
    * Docstrings. In most cases, the docstrings contains the informal explanation of the formal statement, written by human. In this case, you should make good use of the doctrings and include all mathematical information in the docstrings in your translation of statement. Sometimes the docstring also contains implimentation notes, which should not appear in your translation.
    * Neighbor statements that are next to the given statement.
    * Dependent definitions or statements used in the instance.
-   * Similar translation exemplary statements. They are written by human and attached information of the exemplary statements and of high quality. You should learn their way of using the information and follow their style of informalization.
 
    Utilize these information to better understand the formal instance. Make sure you follow the principles of informal statement when you translate the formal instance into informal statement.
 

--- a/prompt/theorem.md.j2
+++ b/prompt/theorem.md.j2
@@ -3,7 +3,7 @@
 
 Suppose you are an expert mathematician and an expert in Lean and Mathlib.
 
-1. Your task is to first translate the formal theorem provided below into an informal statement that is more accessible to mathematicians written in Latex. There are five parts of information attached to the theorem.
+1. Your task is to first translate the formal theorem provided below into an informal statement that is more accessible to mathematicians written in Latex. There are four parts of information attached to the theorem.
 
    * Head statements, including important statements, theorems, definitions of the mathematical field the theorem in.
    * Docstrings. In most cases, the docstrings contains the informal explanation of the formal statement, written by human. In this case, you should make good use of the docstrings and include all mathematical information in the docstrings in your translation of statement. Sometimes the docstring also contains implementation notes, which should not appear in your translation.

--- a/prompt/theorem.md.j2
+++ b/prompt/theorem.md.j2
@@ -9,7 +9,6 @@ Suppose you are an expert mathematician and an expert in Lean and Mathlib.
    * Docstrings. In most cases, the docstrings contains the informal explanation of the formal statement, written by human. In this case, you should make good use of the docstrings and include all mathematical information in the docstrings in your translation of statement. Sometimes the docstring also contains implementation notes, which should not appear in your translation.
    * Neighbor statements that are next to the given statement.
    * Dependent definitions or statements used in the theorem.
-   * Similar translation exemplary statements. They are written by human and attached information of the exemplary statements and of high quality. You should learn their way of using the information and follow their style of informalization.
 
    Utilize these information to better understand the formal theorem. Make sure you follow the principles of informal statement when you translate the formal theorem into informal statement.
 


### PR DESCRIPTION
### This PR

- adds a comment about why LeanSearch doesn't use json-formatted llm outputs
- removes reference to nonexisting exemplary statements from the prompt