### PR TITLE
feat: don't include body dependencies if it's a theorem

### DIFF
--- a/database/jixia_db.py
+++ b/database/jixia_db.py
@@ -138,7 +138,7 @@ def load_data(project: LeanProject, prefixes: list[LeanName], conn: Connection):
                 ON CONFLICT DO NOTHING
             """, values)
 
-            if s.value_references is not None:
+            if s.value_references is not None and s.kind != "theorem":
                 values = ({
                     "source": Jsonb(s.name),
                     "target": Jsonb(t),


### PR DESCRIPTION
### This PR

Right now, LeanSearch is including symbols used in a proof of the theorem as this theorem's dependencies.
I think this doesn't help the informalization, and maybe even confuses it - anything can be used in the body of the proof, for example a proof about integers can depend on theorems about reals.
This PR removes such "theorem body" dependencies.

For example, given the following project:

```lean
-- Level 0
def is_even (n : Nat) := n % 2 = 0

def is_odd (n : Nat) := n % 2 = 1

-- Level 1
-- typeDeps: [is_even]
-- bodyDeps: [is_even]
theorem even_plus_even (a b : Nat) :
  is_even a → is_even b → is_even (a + b) := by
  intro ha hb
  unfold is_even at *
  sorry
  
-- Level 1
-- typeDeps: [is_even, is_odd]
-- bodyDeps: [is_even, is_odd]
theorem odd_plus_odd (a b : Nat) :
  is_odd a → is_odd b → is_even (a + b) := by
  intro ha hb
  unfold is_odd is_even at *
  sorry

-- Level 2
-- typeDeps: [is_even, is_odd]
-- bodyDeps: [is_even, even_plus_even, odd_plus_odd]
theorem sum_four_nums (a b c d : Nat) :
  is_even a → is_even b → is_odd c → is_odd d → is_even (a + b + c + d) := by
  intro ha hb hc hd
  have h1 : is_even (a + b) := even_plus_even a b ha hb
  have h2 : is_even (c + d) := odd_plus_odd c d hc hd
  sorry
```

### Before

<img width="350px" src="https://github.com/user-attachments/assets/3553942c-60d0-43ad-adee-83919c813d15"/>

### After

<img width="350px" src="https://github.com/user-attachments/assets/2b6d9167-23da-40e7-afd5-f260bce87827"/>
