### PR TITLE
refactor: factor out schema creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+# These are `make` commands that are useful for development.
+# 
+# Before running these `make` commands, make sure to set
+# DBNAME, INDEXED_REPO_PATH, MODULE_NAMES, CHROMA_PATH env vars.
+# 
+# For example, you can have the following in your ~/.bashrc:
+# 
+# export DBNAME=magic
+# export INDEXED_REPO_PATH=/home/lakesare/Desktop/magic
+# export MODULE_NAMES=Magic
+# export CHROMA_PATH=chroma
+
+check_env:
+	@test -n "$(DBNAME)"            || (echo "Please set DBNAME in your .env"            && exit 1)
+	@test -n "$(INDEXED_REPO_PATH)" || (echo "Please set INDEXED_REPO_PATH in your .env" && exit 1)
+	@test -n "$(MODULE_NAMES)"      || (echo "Please set MODULE_NAMES in your .env"      && exit 1)
+	@test -n "$(CHROMA_PATH)"       || (echo "Please set MODULE_NAMES in your .env"      && exit 1)
+
+reset:
+	make check_env
+	@echo "\n__________________Dropping and recreating PostgreSQL database '$(DBNAME)'..."
+	-dropdb $(DBNAME)
+	createdb $(DBNAME)
+	@echo "\n__________________Clearing ChromaDB files..."
+	rm -rf $(CHROMA_PATH)
+	@echo "\n__________________Clearing build outputs..."
+	cd $(INDEXED_REPO_PATH) && lake clean && lake build
+	cd $(INDEXED_REPO_PATH) && rm -rf ./.jixia
+	@echo "\n__________________Creating database schema..."
+	python3 -m database schema
+	@echo "\n__________________DONE."
+
+jixia:
+	make reset
+	@echo "\n__________________Parsing the project using jixia..."
+	python3 -m database jixia $(INDEXED_REPO_PATH) $(MODULE_NAMES)
+
+informal:
+	make reset
+	make jixia
+	@echo "\n__________________Creating informal descriptions using DeepSeek..."
+	python3 -m database informal
+
+index:
+	make reset
+	make informal
+	@echo "\n__________________Creating embeddings using Mistral..."
+	python3 -m database vector-db

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -8,11 +8,13 @@ from jixia.structs import parse_name
 from .informalize import generate_informal
 from .jixia_db import load_data
 from .vector_db import create_vector_db
-
+from .create_schema import create_schema
 
 def main():
     parser = ArgumentParser()
     subparser = parser.add_subparsers()
+    schema_parser = subparser.add_parser("schema")
+    schema_parser.set_defaults(command="schema")
     jixia_parser = subparser.add_parser("jixia")
     jixia_parser.set_defaults(command="jixia")
     jixia_parser.add_argument("project_root", help="Project to be indexed")
@@ -38,7 +40,9 @@ def main():
     args = parser.parse_args()
 
     with psycopg.connect(os.environ["CONNECTION_STRING"], autocommit=True) as conn:
-        if args.command == "jixia":
+        if args.command == "schema":
+            create_schema(conn)
+        elif args.command == "jixia":
             project = LeanProject(args.project_root)
             prefixes = [parse_name(p) for p in args.prefixes.split(",")]
             load_data(project, prefixes, conn)

--- a/database/create_schema.py
+++ b/database/create_schema.py
@@ -4,7 +4,7 @@ from psycopg import Connection
 def create_schema(conn: Connection):
     sql : list[LiteralString] = [
         """
-        CREATE TABLE IF NOT EXISTS module (
+        CREATE TABLE module (
             name JSONB PRIMARY KEY,
             content BYTEA NOT NULL,
             docstring TEXT
@@ -28,7 +28,7 @@ def create_schema(conn: Connection):
         """,
 
         """
-        CREATE TABLE IF NOT EXISTS symbol (
+        CREATE TABLE symbol (
             name JSONB PRIMARY KEY,
             module_name JSONB REFERENCES module(name) NOT NULL,
             type TEXT NOT NULL,
@@ -37,7 +37,7 @@ def create_schema(conn: Connection):
         """,
 
         """
-        CREATE TABLE IF NOT EXISTS declaration (
+        CREATE TABLE declaration (
             module_name JSONB REFERENCES module(name) NOT NULL,
             index INTEGER NOT NULL,
             name JSONB UNIQUE REFERENCES symbol(name),
@@ -51,7 +51,7 @@ def create_schema(conn: Connection):
         """,
 
         """
-        CREATE TABLE IF NOT EXISTS dependency (
+        CREATE TABLE dependency (
             source JSONB REFERENCES symbol(name) NOT NULL,
             target JSONB REFERENCES symbol(name) NOT NULL,
             on_type BOOLEAN NOT NULL,
@@ -60,14 +60,14 @@ def create_schema(conn: Connection):
         """,
 
         """
-        CREATE TABLE IF NOT EXISTS level (
+        CREATE TABLE level (
             symbol_name JSONB PRIMARY KEY REFERENCES symbol(name) NOT NULL,
             level INTEGER NOT NULL
         )
         """,
 
         """
-        CREATE TABLE IF NOT EXISTS informal (
+        CREATE TABLE informal (
             symbol_name JSONB PRIMARY KEY REFERENCES symbol(name) NOT NULL,
             name TEXT NOT NULL,
             description TEXT NOT NULL
@@ -75,7 +75,7 @@ def create_schema(conn: Connection):
         """,
 
         """
-        CREATE OR REPLACE VIEW record AS
+        CREATE VIEW record AS
         SELECT
             d.module_name, d.index, d.kind, d.name, d.signature, s.type, d.value, d.docstring,
             i.name AS informal_name, i.description AS informal_description

--- a/database/create_schema.py
+++ b/database/create_schema.py
@@ -1,0 +1,91 @@
+from typing import LiteralString
+from psycopg import Connection
+
+def create_schema(conn: Connection):
+    sql : list[LiteralString] = [
+        """
+        CREATE TABLE IF NOT EXISTS module (
+            name JSONB PRIMARY KEY,
+            content BYTEA NOT NULL,
+            docstring TEXT
+        )
+        """,
+
+        """
+        CREATE TYPE declaration_kind AS ENUM (
+            'abbrev',
+            'axiom',
+            'classInductive',
+            'definition',
+            'example',
+            'inductive',
+            'instance',
+            'opaque',
+            'structure',
+            'theorem',
+            'proofWanted'
+        )
+        """,
+
+        """
+        CREATE TABLE IF NOT EXISTS symbol (
+            name JSONB PRIMARY KEY,
+            module_name JSONB REFERENCES module(name) NOT NULL,
+            type TEXT NOT NULL,
+            is_prop BOOLEAN NOT NULL
+        )
+        """,
+
+        """
+        CREATE TABLE IF NOT EXISTS declaration (
+            module_name JSONB REFERENCES module(name) NOT NULL,
+            index INTEGER NOT NULL,
+            name JSONB UNIQUE REFERENCES symbol(name),
+            visible BOOLEAN NOT NULL,
+            docstring TEXT,
+            kind declaration_kind NOT NULL,
+            signature TEXT NOT NULL,
+            value TEXT,
+            PRIMARY KEY (module_name, index)
+        )
+        """,
+
+        """
+        CREATE TABLE IF NOT EXISTS dependency (
+            source JSONB REFERENCES symbol(name) NOT NULL,
+            target JSONB REFERENCES symbol(name) NOT NULL,
+            on_type BOOLEAN NOT NULL,
+            PRIMARY KEY (source, target, on_type)
+        )
+        """,
+
+        """
+        CREATE TABLE IF NOT EXISTS level (
+            symbol_name JSONB PRIMARY KEY REFERENCES symbol(name) NOT NULL,
+            level INTEGER NOT NULL
+        )
+        """,
+
+        """
+        CREATE TABLE IF NOT EXISTS informal (
+            symbol_name JSONB PRIMARY KEY REFERENCES symbol(name) NOT NULL,
+            name TEXT NOT NULL,
+            description TEXT NOT NULL
+        )
+        """,
+
+        """
+        CREATE OR REPLACE VIEW record AS
+        SELECT
+            d.module_name, d.index, d.kind, d.name, d.signature, s.type, d.value, d.docstring,
+            i.name AS informal_name, i.description AS informal_description
+        FROM
+            declaration d
+            INNER JOIN informal i ON d.name = i.symbol_name
+            INNER JOIN symbol s ON d.name = s.name
+        """,
+    ]
+
+    with conn.cursor() as cursor:
+        for s in sql:
+            cursor.execute(s)


### PR DESCRIPTION
### This PR

- **creates `python3 -m database schema` command, which creates a database schema**
  This is necessary for the caching mechanism (in future PRs), and this is necessary for the Metaprogramming search/per-project search we were discussing on Zulip.
  Database will always stay the same, and we will be adding new projects to the database with other commands.
- **removes all  "IF NOT EXISTS" and "OR REPLACE" from schema creation**
  These additions are not necessary anymore, since schema creation only runs once. Further changes to the schema can be done via migrations.
- **creates Makefile with commands useful for development and testing**