### PR TITLE
feat: ruff proposal

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,19 +10,19 @@ jobs:
       - uses: astral-sh/ruff-action@v3
       - run: ruff check
   
-  typecheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4  # Make sure this is included
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'  # Specify your version
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt  # Or your dependency file
-      - name: Run Pyright
-        uses: jakebailey/pyright-action@v2
-        with:
-          project: ./pyrightconfig.json  # If you have a config file
+  # typecheck:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4  # Make sure this is included
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: '3.x'  # Specify your version
+  #     - name: Install dependencies
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install -r requirements.txt  # Or your dependency file
+  #     - name: Run Pyright
+  #       uses: jakebailey/pyright-action@v2
+  #       with:
+  #         project: ./pyrightconfig.json  # If you have a config file

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,5 @@
 name: lint
+
 on: [push, pull_request]
 
 jobs:
@@ -8,3 +9,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
       - run: ruff check
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: Install Pyright
+        run: npm install -g pyright
+      - name: Run Pyright
+        run: pyright

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,15 +9,20 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
       - run: ruff check
-
+  
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4  # Make sure this is included
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          node-version: '16'
-      - name: Install Pyright
-        run: npm install -g pyright
+          python-version: '3.x'  # Specify your version
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt  # Or your dependency file
       - name: Run Pyright
-        run: pyright
+        uses: jakebailey/pyright-action@v2
+        with:
+          project: ./pyrightconfig.json  # If you have a config file

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,4 +8,3 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
       - run: ruff check
-      - run: ruff format --check

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,5 @@
 name: lint
-on: [push]
+on: [push, pull_request]
 
 jobs:
   lint:

--- a/ruff.toml
+++ b/ruff.toml
@@ -37,8 +37,14 @@ target-version = "py39"
 
 [lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
-# Note the formatter takes care of trailing commas
-select = ["E4", "E7", "E9", "F", "W292"]
+select = ["E4", "E7", "E9", "F",
+    # missing-newline-at-end-of-file
+    "W292",
+    # trailing commas
+    "COM812", "COM819",
+    # use double quotes
+    "Q000"
+]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
@@ -47,16 +53,3 @@ unfixable = []
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-
-[format]
-# Like Black, use double quotes for strings.
-quote-style = "double"
-
-# Like Black, indent with spaces, rather than tabs.
-indent-style = "space"
-
-# Like Black, respect magic trailing commas.
-skip-magic-trailing-comma = false
-
-# Like Black, automatically detect the appropriate line ending.
-line-ending = "auto"


### PR DESCRIPTION
### This PR

- **removes `ruff format`** (as proposed here https://github.com/frenzymath/LeanSearch/pull/9#issuecomment-2855383382)
- **instead of `ruff format`, adds additional linting rules**
- **adds the "linting passed" banner on PRs**

  <img width="600" src="https://github.com/user-attachments/assets/dbe45df4-de7d-4ad6-91ae-5f74beb14923">

- **adds Pyright typechecker** (the same type-checker that's used in Pylance)
  The type-checker will be failing for now, so I commented it out (to avoid scaring users/contributors with the ❌ symbol) - but I checked it, and it works. Let's uncomment it in a later PR, after we fix all type-checker issues.
