### PR TITLE
feat: create `python -m prefix` helper command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ python -m pip install -r requirements.txt
     - `project root`: Path to the project to index. This is where the `lakefile.toml` or `lakefile.lean` is located.
     - `prefixes`: Comma-separated list of module prefixes. A module is indexed only if its module path starts with one of prefixes listed here.  For example, `Init,Lean,Mathlib` will include only `Init.*`, `Lean.*`, and `Mathlib.*` modules.
 
+    Note: to check what modules are available in your project, and to determine how prefixes work, you can use `python -m prefix --project_root <project_root> --prefixes <prefixes>` helper command.
+
 3. **Create informal descriptions** (uses DeepSeek api, puts results into PostgreSQL)
 
    ```shell

--- a/prefix.py
+++ b/prefix.py
@@ -10,7 +10,7 @@ def main(project_root: str, prefixes: str | None) -> None:
     all_modules = project.find_modules()
 
     print("____________ALL MODULES_____________")
-    formatted_modules = ['/'.join(str(x) for x in module) for module in all_modules]
+    formatted_modules = ['.'.join(str(x) for x in module) for module in all_modules]
     for module in formatted_modules:
         print(module)
 
@@ -19,7 +19,7 @@ def main(project_root: str, prefixes: str | None) -> None:
         lean_names : list[LeanName] = [parse_name(p) for p in prefixes.split(",")]
         matching_modules = [m for m in all_modules if any(is_prefix_of(p, m) for p in lean_names)]
         # Format the matching modules with slashes
-        formatted_matching = ['/'.join(str(x) for x in module) for module in matching_modules]
+        formatted_matching = ['.'.join(str(x) for x in module) for module in matching_modules]
         for module in formatted_matching:
             print(module)
 

--- a/prefix.py
+++ b/prefix.py
@@ -1,0 +1,37 @@
+from argparse import ArgumentParser
+import os
+from pathlib import Path
+import dotenv
+from jixia import LeanProject
+from jixia.structs import parse_name, is_prefix_of, LeanName
+
+def main(project_root: str, prefixes: str | None) -> None:
+    project = LeanProject(project_root)
+    all_modules = project.find_modules()
+
+    print("____________ALL MODULES_____________")
+    formatted_modules = ['/'.join(str(x) for x in module) for module in all_modules]
+    for module in formatted_modules:
+        print(module)
+
+    if prefixes is not None:
+        print("__________MODULES THAT MATCH YOUR PREFIX___________")
+        lean_names : list[LeanName] = [parse_name(p) for p in prefixes.split(",")]
+        matching_modules = [m for m in all_modules if any(is_prefix_of(p, m) for p in lean_names)]
+        # Format the matching modules with slashes
+        formatted_matching = ['/'.join(str(x) for x in module) for module in matching_modules]
+        for module in formatted_matching:
+            print(module)
+
+if __name__ == "__main__":
+    dotenv.load_dotenv()
+    path_to_lean = path_to_lean = Path(os.environ["LEAN_SYSROOT"]) / "src" / "lean"
+    parser = ArgumentParser(description=f"""
+        Helper command that helps you understand what files are available for indexing.
+        For example, you can run it with:
+        python -m prefix --project_root "{path_to_lean}" --prefixes Init.Grind,Init.Control.Lawful
+    """)
+    parser.add_argument("--project_root", help="Path to the project you want to index", required=False)
+    parser.add_argument("--prefixes", help="Comma-separated list of module prefixes to be included in the index; e.g., Init.Grind,Init.Control.Lawful", required=False)
+    args = parser.parse_args()
+    main(args.project_root, args.prefixes)

--- a/prefix.py
+++ b/prefix.py
@@ -5,23 +5,28 @@ import dotenv
 from jixia import LeanProject
 from jixia.structs import parse_name, is_prefix_of, LeanName
 
+def format(lean_name: LeanName, with_indent: bool = False) -> str:
+    formatted = '.'.join(str(x) for x in lean_name)
+    indent = '  ' * (len(lean_name) - 1) if with_indent else ''
+    return f"{indent}{formatted}"
+
+def sort(lean_names: list[LeanName]) -> list[LeanName]:
+    return sorted(lean_names, key=format)
+
 def main(project_root: str, prefixes: str | None) -> None:
     project = LeanProject(project_root)
-    all_modules = project.find_modules()
+    all_module_names : list[LeanName] = project.find_modules()
 
     print("____________ALL MODULES_____________")
-    formatted_modules = ['.'.join(str(x) for x in module) for module in all_modules]
-    for module in formatted_modules:
-        print(module)
+    for module_name in sort(all_module_names):
+        print(format(module_name, with_indent=True))
 
     if prefixes is not None:
         print("__________MODULES THAT MATCH YOUR PREFIX___________")
-        lean_names : list[LeanName] = [parse_name(p) for p in prefixes.split(",")]
-        matching_modules = [m for m in all_modules if any(is_prefix_of(p, m) for p in lean_names)]
-        # Format the matching modules with slashes
-        formatted_matching = ['.'.join(str(x) for x in module) for module in matching_modules]
-        for module in formatted_matching:
-            print(module)
+        prefix_names : list[LeanName] = [parse_name(p) for p in prefixes.split(",")]
+        matching_names = [n for n in all_module_names if any(is_prefix_of(p, n) for p in prefix_names)]
+        for module_name in sort(matching_names):
+            print(format(module_name))
 
 if __name__ == "__main__":
     dotenv.load_dotenv()


### PR DESCRIPTION
### This PR

Creates the `python -m prefix --project_root <> --prefixes <>` command that's useful for seeing what modules are available in a repo.

### Example

```bash
python -m prefix --project_root "/home/lakesare/.elan/toolchains/leanprover--lean4---v4.18.0/src/lean" --prefixes "Init.Grind,Init.Control.Lawful"
```

will return

```
...
Init/Data/Sum/Basic
Init/Data/Sum/Lemmas
Init/Data/Option/List
Init/Data/Option/Instances
Init/Data/Option/Basic
Init/Data/Option/Lemmas
Init/Data/Option/Monadic
Init/Data/Option/BasicAux
Init/Data/Option/Attach
Init/Data/Range/Basic
Init/Data/Range/Lemmas
Init/System/Platform
Init/System/IOError
Init/System/Mutex
Init/System/Promise
Init/System/IO
Init/System/FilePath
Init/System/Uri
Init/System/ST
Init/Omega/Int
Init/Omega/Logic
Init/Omega/Constraint
Init/Omega/Coeffs
Init/Omega/LinearCombo
Init/Omega/IntList
Init/Grind/Cases
Init/Grind/Tactics
Init/Grind/PP
Init/Grind/Util
Init/Grind/Lemmas
Init/Grind/Offset
Init/Grind/Norm
Init/Grind/Propagator
Init/Control/Id
Init/Control/Except
Init/Control/Reader
Init/Control/Lawful
Init/Control/Basic
Init/Control/EState
Init/Control/ExceptCps
Init/Control/StateRef
Init/Control/State
Init/Control/Option
Init/Control/StateCps
Init/Control/Lawful/Instances
Init/Control/Lawful/Basic
Init/Control/Lawful/Lemmas
__________MODULES THAT MATCH YOUR PREFIX___________
Init/Grind
Init/Grind/Cases
Init/Grind/Tactics
Init/Grind/PP
Init/Grind/Util
Init/Grind/Lemmas
Init/Grind/Offset
Init/Grind/Norm
Init/Grind/Propagator
Init/Control/Lawful
Init/Control/Lawful/Instances
Init/Control/Lawful/Basic
Init/Control/Lawful/Lemmas
```