### PR TITLE
feat: make dry runs possible

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,12 +31,17 @@ CHROMA_PATH = "chroma"
 EMBEDDING_DEVICE = "cpu"
 
 # Name of the log file.
-# "" results in logging to console.
+# Values: "" results in logging to console.
 LOG_FILENAME = ""
 
 # Log file mode.
-# "w" for overwriting and "a" for appending.
+# Values: "w" for overwriting and "a" for appending.
 LOG_FILEMODE = "w"
 
 # Log level.
 LOG_LEVEL = "WARNING"
+
+# Dry run - runs indexing commands without calling DeepSeek api, and without computing embeddings.
+# Real informalizations will be superseded with fake values; and embeddings won't be computed or added to chroma.
+# Values: "true" for the dry run, "false" for the normal run.
+DRY_RUN = "false"

--- a/database/translate.py
+++ b/database/translate.py
@@ -61,6 +61,9 @@ class TranslationEnvironment:
         else:
             kind = "definition" if data.value_matters else "theorem"
         prompt = await self.template[kind].render_async(input=data)
+        if os.environ["DRY_RUN"] == "true":
+            logger.info("DRY_RUN:skipped informalization: %s", data.name)
+            return "Fake Name", f"Fake Description\nPrompt:\n{data}"
         for _ in range(5):
             try:
                 response = await self.client.chat.completions.create(


### PR DESCRIPTION
### This PR

Adds `DRY_RUN` env var.

If we have `DRY_RUN = "true"`, everything works as it previously did.
If we have `DRY_RUN = "false"`, fake informalizations will be added to the database, and embeddings won't be computed.

This lets us test the new codebase on Mathlib/other repos in a few minutes without worrying about costs/embedding compute time.

### Example

The template for the informalization (that doesn't create calls to DeepSeek during the dry run) is stored in the database to make potential debugging easy.
So, `informal.description` text field will look like as follows:

```
Fake Description

Prompt:

TranslationInput(
  name=['is_odd'], signature=' (n : Nat)', value=':= n % 2 = 1', docstring=None, kind='definition', header='{}',
  neighbor=[
    TranslatedItem(name=['is_even'], description=' (n : Nat)', informal_name=None, informal_description=None), 
    TranslatedItem(name=['is_odd'], description=' (n : Nat)', informal_name=None, informal_description=None), 
    TranslatedItem(name=['even_plus_even'], description=' (a b : Nat) : is_even a → is_even b → is_even (a + b)', informal_name=None, informal_description=None), TranslatedItem(name=['odd_plus_odd'], description=' (a b : Nat) : is_odd a → is_odd b → is_even (a + b)', informal_name=None, informal_description=None)
  ],
  dependency=[]
)
```