### PR TITLE
[WIP] feat - start parsing metaprogramming functions

### DIFF
--- a/database/__init__.py
+++ b/database/__init__.py
@@ -9,6 +9,7 @@ from .informalize import generate_informal
 from .jixia_db import load_data
 from .vector_db import create_vector_db
 from .create_schema import create_schema
+from .migrate import migrate
 
 
 def main():
@@ -43,6 +44,8 @@ def main():
     args = parser.parse_args()
 
     with psycopg.connect(os.environ["CONNECTION_STRING"], autocommit=True) as conn:
+        if args.command == "migrate":
+            migrate(conn)
         if args.command == "schema":
             create_schema(conn)
         elif args.command == "jixia":

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -38,7 +38,6 @@ def main():
         type=int,
         help="Limit max number of items per level. Used for testing.",
     )
-    informal_parser.add_argument("--project-name")
     vector_db_parser = subparser.add_parser("vector-db")
     vector_db_parser.set_defaults(command="vector-db")
     vector_db_parser.add_argument("--batch-size", type=int, default=8)
@@ -58,7 +57,6 @@ def main():
         elif args.command == "informal":
             generate_informal(
                 conn,
-                project_name=args.project_name,
                 batch_size=args.batch_size,
                 limit_level=args.limit_level,
                 limit_num_per_level=args.limit_num_per_level,

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -24,6 +24,7 @@ def main():
         "prefixes",
         help="Comma-separated list of module prefixes to be included in the index; e.g., Init,Mathlib",
     )
+    jixia_parser.add_argument("--project-name")
     informal_parser = subparser.add_parser("informal")
     informal_parser.set_defaults(command="informal")
     informal_parser.add_argument("--batch-size", type=int, default=50)
@@ -37,9 +38,11 @@ def main():
         type=int,
         help="Limit max number of items per level. Used for testing.",
     )
+    informal_parser.add_argument("--project-name")
     vector_db_parser = subparser.add_parser("vector-db")
     vector_db_parser.set_defaults(command="vector-db")
     vector_db_parser.add_argument("--batch-size", type=int, default=8)
+    vector_db_parser.add_argument("--project-name")
 
     args = parser.parse_args()
 
@@ -51,13 +54,14 @@ def main():
         elif args.command == "jixia":
             project = LeanProject(args.project_root)
             prefixes = [parse_name(p) for p in args.prefixes.split(",")]
-            load_data(project, prefixes, conn)
+            load_data(project, prefixes, conn, project_name=args.project_name)
         elif args.command == "informal":
             generate_informal(
                 conn,
+                project_name=args.project_name,
                 batch_size=args.batch_size,
                 limit_level=args.limit_level,
                 limit_num_per_level=args.limit_num_per_level,
             )
         elif args.command == "vector-db":
-            create_vector_db(conn, os.environ["CHROMA_PATH"], batch_size=args.batch_size)
+            create_vector_db(conn, os.environ["CHROMA_PATH"], batch_size=args.batch_size, project_name=args.project_name)

--- a/database/informalize.py
+++ b/database/informalize.py
@@ -51,7 +51,7 @@ def find_dependency(conn: Connection, name: LeanName) -> list[TranslatedItem]:
         return cursor.fetchall()
 
 
-def generate_informal(conn: Connection, project_name: str, batch_size: int = 50, limit_level: int | None = None, limit_num_per_level: int | None = None):
+def generate_informal(conn: Connection, batch_size: int = 50, limit_level: int | None = None, limit_num_per_level: int | None = None):
     max_level: int
     if limit_level is None:
         with conn.cursor(row_factory=scalar_row) as cursor:
@@ -63,7 +63,7 @@ def generate_informal(conn: Connection, project_name: str, batch_size: int = 50,
     with conn.cursor() as cursor, conn.cursor() as insert_cursor:
         for level in range(max_level + 1):
             query = """
-                SELECT s.name, d.signature, d.value, d.docstring, d.kind, m.docstring, d.module_name, d.index
+                SELECT s.name, d.signature, d.value, d.docstring, d.kind, m.docstring, d.module_name, d.index, m.project_name
                 FROM
                     symbol s
                     INNER JOIN declaration d ON s.name = d.name
@@ -98,7 +98,7 @@ def generate_informal(conn: Connection, project_name: str, batch_size: int = 50,
 
                 tasks.clear()
                 for row in batch:
-                    name, signature, value, docstring, kind, header, module_name, index = row
+                    name, signature, value, docstring, kind, header, module_name, index, project_name = row
 
                     logger.info("translating %s", name)
                     neighbor = find_neighbor(conn, module_name, index)

--- a/database/informalize.py
+++ b/database/informalize.py
@@ -51,7 +51,7 @@ def find_dependency(conn: Connection, name: LeanName) -> list[TranslatedItem]:
         return cursor.fetchall()
 
 
-def generate_informal(conn: Connection, batch_size: int = 50, limit_level: int | None = None, limit_num_per_level: int | None = None):
+def generate_informal(conn: Connection, project_name: str, batch_size: int = 50, limit_level: int | None = None, limit_num_per_level: int | None = None):
     max_level: int
     if limit_level is None:
         with conn.cursor(row_factory=scalar_row) as cursor:
@@ -113,6 +113,7 @@ def generate_informal(conn: Connection, batch_size: int = 50, limit_level: int |
                         header=header,
                         neighbor=neighbor,
                         dependency=dependency,
+                        project_name=project_name,
                     )
                     tasks.append(translate_and_insert(name, ti))
 

--- a/database/informalize.py
+++ b/database/informalize.py
@@ -16,9 +16,12 @@ def find_neighbor(conn: Connection, module_name: LeanName, index: int, num_neigh
     with conn.cursor(row_factory=args_row(TranslatedItem)) as cursor:
         cursor.execute(
             """
-            SELECT d.name, d.signature, i.name, i.description
+            SELECT s.name, d.signature, d.value, d.docstring, d.kind, i.name, i.description, d.signature
             FROM
-                declaration d
+                symbol s
+                INNER JOIN declaration d ON s.name = d.name
+                INNER JOIN module m ON s.module_name = m.name
+                INNER JOIN level l ON s.name = l.symbol_name
                 LEFT JOIN informal i ON d.name = i.symbol_name
             WHERE
                 d.module_name = %s AND d.index >= %s AND d.index <= %s
@@ -32,11 +35,14 @@ def find_dependency(conn: Connection, name: LeanName) -> list[TranslatedItem]:
     with conn.cursor(row_factory=args_row(TranslatedItem)) as cursor:
         cursor.execute(
             """
-            SELECT d.name, d.signature, i.name, i.description
+            SELECT s.name, d.signature, d.value, d.docstring, d.kind, i.name, i.description, d.signature
             FROM
-                declaration d
-                INNER JOIN dependency e ON d.name = e.target
+                symbol s
+                INNER JOIN declaration d ON s.name = d.name
+                INNER JOIN module m ON s.module_name = m.name
+                INNER JOIN level l ON s.name = l.symbol_name
                 LEFT JOIN informal i ON d.name = i.symbol_name
+                INNER JOIN dependency e ON d.name = e.target
             WHERE
                 e.source = %s
             """,

--- a/database/jixia_db.py
+++ b/database/jixia_db.py
@@ -24,12 +24,12 @@ def _get_value(declaration: Declaration, module_content):
     else:
         return None
 
-def load_data(project: LeanProject, prefixes: list[LeanName], conn: Connection):
+def load_data(project: LeanProject, prefixes: list[LeanName], conn: Connection, project_name):
     def load_module(data: Iterable[LeanName], base_dir: Path):
-        values = ((Jsonb(m), project.path_of_module(m, base_dir).read_bytes(), project.load_module_info(m).docstring) for m in data)
+        values = ((Jsonb(m), project.path_of_module(m, base_dir).read_bytes(), project.load_module_info(m).docstring, project_name) for m in data)
         cursor.executemany(
             """
-            INSERT INTO module (name, content, docstring) VALUES (%s, %s, %s) ON CONFLICT DO NOTHING
+            INSERT INTO module (name, content, docstring, project_name) VALUES (%s, %s, %s, %s) ON CONFLICT DO NOTHING
             """,
             values,
         )

--- a/database/migrate.py
+++ b/database/migrate.py
@@ -1,0 +1,6 @@
+from psycopg import Connection
+
+def migrate(conn: Connection):
+    with conn.cursor() as cursor:
+        cursor.execute("ALTER TABLE module ADD COLUMN project_name TEXT")
+        cursor.execute("UPDATE module SET project_name = 'mathlib'")

--- a/database/translate.py
+++ b/database/translate.py
@@ -4,11 +4,13 @@ import os
 import re
 from dataclasses import dataclass
 from json import JSONDecodeError
+import xml.etree.ElementTree as ET
 
 import jinja2
 from jinja2 import Environment, FileSystemLoader
 from jixia.structs import DeclarationKind, LeanName, pp_name
 from openai import AsyncOpenAI
+from prompt.metaprogramming import metaprogramming_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -16,10 +18,16 @@ logger = logging.getLogger(__name__)
 @dataclass
 class TranslatedItem:
     name: LeanName
-    description: str
+    signature: str
+    value: str | None
+    docstring: str | None
+    kind: DeclarationKind
+
     informal_name: str | None
     informal_description: str | None
 
+    # The "description" field is a copypaste of the more appropriately named "signature" field, it's here for backwards compatibility, and can be removed when all prompts are switch to using the "signature" field.
+    description: str
 
 @dataclass
 class TranslationInput:

--- a/meta_instructions.md
+++ b/meta_instructions.md
@@ -1,4 +1,0 @@
-
-# Indexing metaprogramming functions
-
-1. Run `python -m database migrate`

--- a/meta_instructions.md
+++ b/meta_instructions.md
@@ -1,0 +1,4 @@
+
+# Indexing metaprogramming functions
+
+1. Run `python -m database migrate`

--- a/prompt/metaprogramming.py
+++ b/prompt/metaprogramming.py
@@ -1,0 +1,39 @@
+def format_declaration(declaration):
+    result : list[str] = []
+
+    result.append("<declaration>")
+    result.append(f"<docstring>{declaration['docstring']}</docstring>")
+    result.append(f"<name>{declaration['name']}</name>")
+    result.append(f"<signature>{declaration['description']}</signature>")
+    result.append(f"<definition>{declaration['value']}</definition>")
+    if declaration['informal_name'] is not None:
+        result.append(f"<informal_name>{declaration['informal_name']}</informal_name>")
+    if declaration['informal_description'] is not None:
+        result.append(f"<informal_description>{declaration['informal_description']}</informal_description>")
+    result.append("</declaration>")
+
+    return "\n".join(result)
+
+def format_input(input_data):
+    result : list[str] = []
+
+    result.append("<instructions>Your task is to create an informal description of the following metaprogramming declaration in Lean 4. Later on, we will use them to create embedding vectors.</instructions>")
+
+    result.append(f"<file_docstring explanation='This is a docstring in the beginning of the .lean file where the declaration you are informalizing is located'>{input_data['header']}</file_docstring>")
+
+    result.append("<neighbor_declarations explanation='These are the descriptions of the declarations that are located nearby in this Lean file.'>")
+    for neighbor in input_data["neighbor"]:
+        result.append(format_declaration(neighbor))
+    result.append("</neighbor_declarations>")
+
+    result.append("<dependent_declarations explanation='These are the descriptions of the declarations that our declaration depends on.'>")
+    for dependency in input_data["dependency"]:
+        result.append(format_declaration(dependency))
+    result.append("</dependent_declarations>")
+
+    result.append("<instructions>Finally, here is the declaration that you should create the description of.</instructions>")
+    result.append(format_declaration(input_data))
+
+    result.append("<instructions>Please put your informal description into the following format: <informal_name>...<informal_name> (this is where you put the informal name of this Lean 4 declaration), <informal_description>...</informal_description> (this is where you put the informal description of this Lean 4 declaration). You can put your thinking into <thinking>...</thinking> tags.</instructions>")
+
+    return "\n".join(result)

--- a/prompt/metaprogramming.py
+++ b/prompt/metaprogramming.py
@@ -1,38 +1,41 @@
-def format_declaration(declaration):
+from database.translate import TranslatedItem, TranslationInput
+
+
+def format_declaration(declaration: TranslatedItem):
     result : list[str] = []
 
     result.append("<declaration>")
-    result.append(f"<docstring>{declaration['docstring']}</docstring>")
-    result.append(f"<name>{declaration['name']}</name>")
-    result.append(f"<signature>{declaration['description']}</signature>")
-    result.append(f"<definition>{declaration['value']}</definition>")
-    if declaration['informal_name'] is not None:
-        result.append(f"<informal_name>{declaration['informal_name']}</informal_name>")
-    if declaration['informal_description'] is not None:
-        result.append(f"<informal_description>{declaration['informal_description']}</informal_description>")
+    result.append(f"<docstring>{declaration.docstring}</docstring>")
+    result.append(f"<name>{declaration.kind} {declaration.name}</name>")
+    result.append(f"<signature>{declaration.signature}</signature>")
+    result.append(f"<definition>{declaration.value}</definition>")
+    if declaration.informal_name is not None:
+        result.append(f"<informal_name>{declaration.informal_name}</informal_name>")
+    if declaration.informal_description is not None:
+        result.append(f"<informal_description>{declaration.informal_description}</informal_description>")
     result.append("</declaration>")
 
     return "\n".join(result)
 
-def format_input(input_data):
+def metaprogramming_prompt(input : TranslationInput):
     result : list[str] = []
 
     result.append("<instructions>Your task is to create an informal description of the following metaprogramming declaration in Lean 4. Later on, we will use them to create embedding vectors.</instructions>")
 
-    result.append(f"<file_docstring explanation='This is a docstring in the beginning of the .lean file where the declaration you are informalizing is located'>{input_data['header']}</file_docstring>")
+    result.append(f"<file_docstring explanation='This is a docstring in the beginning of the .lean file where the declaration you are informalizing is located'>{input.header}</file_docstring>")
 
     result.append("<neighbor_declarations explanation='These are the descriptions of the declarations that are located nearby in this Lean file.'>")
-    for neighbor in input_data["neighbor"]:
-        result.append(format_declaration(neighbor))
+    for neighbor in input.neighbor:
+        result.append(format_declaration(neighbor)) # type: ignore
     result.append("</neighbor_declarations>")
 
     result.append("<dependent_declarations explanation='These are the descriptions of the declarations that our declaration depends on.'>")
-    for dependency in input_data["dependency"]:
-        result.append(format_declaration(dependency))
+    for dependency in input.dependency:
+        result.append(format_declaration(dependency)) # type: ignore
     result.append("</dependent_declarations>")
 
     result.append("<instructions>Finally, here is the declaration that you should create the description of.</instructions>")
-    result.append(format_declaration(input_data))
+    result.append(format_declaration(input)) # type: ignore
 
     result.append("<instructions>Please put your informal description into the following format: <informal_name>...<informal_name> (this is where you put the informal name of this Lean 4 declaration), <informal_description>...</informal_description> (this is where you put the informal description of this Lean 4 declaration). You can put your thinking into <thinking>...</thinking> tags.</instructions>")
 


### PR DESCRIPTION
### This PR

Creates indexing for metaprogramming functions in Lean 4.

### Instructions for what to do on production server

1. Run `python -m database migrate`
2. Run
    ```
    python -m database jixia <project root TODO> <prefixes TODO> --project-name=metaprogramming
    python -m database informal
    python -m database vector-db --project-name=metaprogramming
    ```

### Instructions for reindexing mathlib and metaprogramming next time

1. Run `make reset`
3. Run `python -m database migrate`
4. To index mathlib, run
    ```
    python -m database jixia <project root> <prefixes> --project-name=mathib
    python -m database informal
    python -m database vector-db --project-name=mathlib
    ```
5. To index metaprogramming functions, run
    ```
    python -m database jixia <project root> <prefixes> --project-name=metaprogramming
    python -m database informal
    python -m database vector-db --project-name=metaprogramming
    ```

### TODOs

- [ ] ensure all of this is backwards-compatible
- [ ] write instructions for how to index mathlib from now on (without thinking about caching)
- [ ] rewrite README.md to include `--project-name`


___

Eric Wieser  ([link](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/feedback.20on.20LeanSearch/near/512132490)):
> If you want to exclude things like tactic parsers / metaprogramming, then probably dropping (or rather, filtering) things in the Lean namespace is a reasonable approximation. Dropping based on which folder things are in probably isn't a good heuristic.